### PR TITLE
Firebase integration

### DIFF
--- a/kvdeveloper/cli.py
+++ b/kvdeveloper/cli.py
@@ -525,9 +525,12 @@ def add_firebase(
     """
     Add firebase service to gradle.json then automatically adds
     com.google.gms:google-services and
-    com.google.firebase:firebase-bom to gradle.json if not exist yet to then
-    update python-for-android build.tmpl.gradle.
-    Optional: Add google-services.json to python-for-android.
+    com.google.firebase:firebase-bom to gradle.json if not exist yet,
+    then runs update_gradle.
+
+    :optional: Add google-services.json to python-for-android.
+
+    :notes: check update_gradle
     """
     gradle_json_path = os.path.join(os.getcwd(), 'gradle.json')
     gradle_json = read_gradle_json(gradle_json_path)
@@ -572,7 +575,10 @@ def add_firebase(
 def update_gradle() -> None:
     """
     Parses KV GRADLE_TEMPLATE to place there the contents of
-    gradle.json and then copies to P4A build.tmpl.gradle
+    gradle.json and then copies to P4A build.tmpl.gradle.
+    
+    :notes: If P4A directory does not exist it's cloned from Github
+    then buildozer.spec p4a.source_dir points to the new cloned repo.
     """
 
     p4a_dir = os.path.join(os.getcwd(), "python-for-android")

--- a/kvdeveloper/cli.py
+++ b/kvdeveloper/cli.py
@@ -1,6 +1,11 @@
-import typer
 import os
 import re
+import json
+import typer
+import shutil
+import itertools
+from pathlib import Path
+
 from typing import Optional, List
 from kvdeveloper import __app_name__, __version__
 from kvdeveloper.config import (
@@ -12,6 +17,8 @@ from kvdeveloper.config import (
     COMPONENTS_DIR,
     COMPONENTS,
     VIEW_BASE,
+    GRADLE_TEMPLATE,
+    P4A_URL
 )
 from kvdeveloper.module import (
     console,
@@ -27,7 +34,7 @@ from kvdeveloper.module import (
     project_info,
 )
 from kvdeveloper.build_config import generate_build_files
-from kvdeveloper.utils import replace_placeholders
+from kvdeveloper.utils import replace_placeholders, read_gradle_json, clone_p4a
 from rich.panel import Panel
 from rich.text import Text
 from rich.table import Table
@@ -503,12 +510,119 @@ def list_components() -> None:
     typer.secho(help_text, fg=typer.colors.BRIGHT_WHITE)
     console.print(components_box)
 
+@app.command()
+def add_firebase(
+    service: str = typer.Argument(
+        help="Firebase service, e.g: com.google.android.gms:play-services-ads"
+        ),
+
+    google_services_json: Optional[str] = typer.Argument(
+        None, help="google-services.json path"
+        )
+) -> None:
+    """
+    Add firebase service to gradle.json then automatically adds
+    com.google.gms:google-services and
+    com.google.firebase:firebase-bom to gradle.json if not exist yet to then
+    update python-for-android build.tmpl.gradle.
+    Optional: Add google-services.json to python-for-android.
+    """
+    gradle_json_path = os.path.join(os.getcwd(), 'gradle.json')
+    gradle_json = read_gradle_json(gradle_json_path)
+
+    # Adding firebase to gradle_json 
+    console.print(f"Adding service: {service}")
+    gradle_json['dep'].append(service)
+    gradle_json['dep'] = list(set(gradle_json['dep']))
+
+    if len(list(filter(lambda x: 'com.google.gms:google-services' in x,
+        gradle_json['classpath']))) == 0:
+        console.print('Adding classpath: com.google.gms:google-services:4.4.2')
+        gradle_json['classpath'].append('com.google.gms:google-services:4.4.2')
+    
+    if len(list(filter(lambda x: 'com.google.gms:google-services' in x,
+        gradle_json['plugin']))) == 0:
+        console.print('Adding plugin: com.google.gms:google-services')
+        gradle_json['plugin'].append('com.google.gms:google-services')
+    
+    if len(list(filter(lambda x: 'com.google.firebase:firebase-bom' in x,
+        gradle_json['bom']))) == 0:
+        console.print('Adding bom: com.google.firebase:firebase-bom:33.8.0')
+        gradle_json['bom'].append('com.google.firebase:firebase-bom:33.8.0')
+
+    console.print(f"Updating {gradle_json_path}")
+    with open(gradle_json_path, 'w') as file:
+        json.dump(gradle_json, file, indent=4)
+    
+    update_gradle()
+
+    if google_services_json is not None:
+        p4a_gs_json = os.path.join(
+                os.getcwd(),
+                "python-for-android/pythonforandroid/bootstraps/common/build/"
+                "google-services.json"
+                )
+
+        console.print(f"Copying {google_services_json} to {p4a_gs_json}")
+        Path(google_services_json).replace(p4a_gs_json)
+
+@app.command()
+def update_gradle() -> None:
+    """
+    Parses KV GRADLE_TEMPLATE to place there the contents of
+    gradle.json and then copies to P4A build.tmpl.gradle
+    """
+
+    p4a_dir = os.path.join(os.getcwd(), "python-for-android")
+    if not os.path.exists(p4a_dir):
+        console.print(f"{p4a_dir} does not exist, cloning it...")
+        clone_p4a(p4a_dir)
+
+    gradle_json_path = os.path.join(os.getcwd(), 'gradle.json')
+    gradle_json = read_gradle_json(gradle_json_path)
+    p4a_gradle_template = os.path.join(
+            p4a_dir,
+            "pythonforandroid/bootstraps/common/build/templates/"
+            "build.tmpl.gradle"
+            )
+
+    console.print(f"Updating {p4a_gradle_template}")
+    with open(p4a_gradle_template, 'w', encoding="utf-8") as file:
+        with open(GRADLE_TEMPLATE, 'r', encoding="utf-8") as template:
+            lines = template.readlines()
+            for line in lines:
+                indent = ''.join(
+                        char for char in itertools.takewhile(
+                            lambda x: x in {' ', '\t'},
+                            line
+                            )
+                        )
+
+                if '{%- gradle_classpath %}' in line:
+                    for classpath in gradle_json['classpath']:
+                        file.write(f"{indent}classpath '{classpath}'\n")
+
+                elif '{%- gradle_plugin %}' in line:
+                    for plugin in gradle_json['plugin']:
+                        file.write(f"{indent}apply plugin: '{plugin}'\n")
+
+                elif '{%- gradle_bom %}' in line:
+                    for bom in gradle_json['bom']:
+                        file.write(
+                                f"{indent}implementation platform('{bom}')\n"
+                                )
+
+                elif '{%- gradle_dep %}' in line:
+                    for dep in gradle_json['dep']:
+                        file.write(f"{indent}implementation '{dep}'\n")
+
+                else:
+                    file.write(line)
 
 def _version_callback(value: bool) -> None:
     if value:
         typer.secho(f"{__app_name__} v{__version__}", fg=typer.colors.BRIGHT_WHITE)
         raise typer.Exit()
-
 
 @app.callback()
 def main(

--- a/kvdeveloper/cli.py
+++ b/kvdeveloper/cli.py
@@ -32,9 +32,11 @@ from kvdeveloper.module import (
     remove_from_structure,
     setup_build,
     project_info,
+    read_gradle_json,
+    clone_p4a,
 )
 from kvdeveloper.build_config import generate_build_files
-from kvdeveloper.utils import replace_placeholders, read_gradle_json, clone_p4a
+from kvdeveloper.utils import replace_placeholders
 from rich.panel import Panel
 from rich.text import Text
 from rich.table import Table
@@ -576,7 +578,7 @@ def update_gradle() -> None:
     p4a_dir = os.path.join(os.getcwd(), "python-for-android")
     if not os.path.exists(p4a_dir):
         console.print(f"{p4a_dir} does not exist, cloning it...")
-        clone_p4a(p4a_dir)
+        clone_p4a(p4a_dir, P4A_URL)
 
     gradle_json_path = os.path.join(os.getcwd(), 'gradle.json')
     gradle_json = read_gradle_json(gradle_json_path)

--- a/kvdeveloper/cli.py
+++ b/kvdeveloper/cli.py
@@ -581,7 +581,7 @@ def update_gradle() -> None:
     then buildozer.spec p4a.source_dir points to the new cloned repo.
     """
 
-    p4a_dir = os.path.join(os.getcwd(), "python-for-android")
+    p4a_dir = os.path.join(os.getcwd(), "python-for-android-2024.01.21")
     if not os.path.exists(p4a_dir):
         console.print(f"{p4a_dir} does not exist, cloning it...")
         clone_p4a(p4a_dir, P4A_URL)

--- a/kvdeveloper/config.py
+++ b/kvdeveloper/config.py
@@ -40,3 +40,7 @@ COMPONENTS = {
 COMPONENTS_DIR =  os.path.join(def_dir, "components")
 
 LIBS_DIR =  os.path.join(def_dir, "libs")
+
+# GRADLE
+GRADLE_TEMPLATE: str = os.path.join(def_dir, "templates/p4a/build.tmpl.gradle")
+P4A_URL = "https://github.com/kivy/python-for-android/archive/refs/tags/v2024.01.21.tar.gz"

--- a/kvdeveloper/module.py
+++ b/kvdeveloper/module.py
@@ -4,6 +4,7 @@ import platform
 import subprocess
 import sys
 import re
+from pathlib import Path
 
 import io
 import json
@@ -15,6 +16,7 @@ from kvdeveloper.utils import (
     name_parser,
     name_parser_snake,
     replace_placeholders,
+    extract_tar_file
 )
 from kvdeveloper.config import (
     TEMPLATES_DIR,
@@ -1024,20 +1026,9 @@ def clone_p4a(p4a_dir: str, url: str):
                     chunk_size=io.DEFAULT_BUFFER_SIZE): 
                 file.write(chunk)
 
-    console.print(f"{p4a_dir} Creating it...")
-    os.mkdir(p4a_dir)
-    untar_command = [
-            "tar", "-xvzf", "python-for-android.tar.gz",
-            "-C", "python-for-android",
-            "--strip-components=1"
-            ]
-
-    console.print(' '.join(untar_command))
-    subprocess.run(
-                untar_command,
-                capture_output=True,
-                check=True
-                )
+    extract_tar_file(f"{p4a_dir}.tar.gz", Path(p4a_dir).parent)
+    console.print(f"Removing: {p4a_dir}.tar.gz")
+    os.remove(f"{p4a_dir}.tar.gz")
 
     with open("buildozer.spec", "r", encoding="utf-8") as build_file:
         content = build_file.readlines()

--- a/kvdeveloper/module.py
+++ b/kvdeveloper/module.py
@@ -1012,7 +1012,7 @@ def read_gradle_json(path: str):
 
                 else:
                     raise ValueError(
-                            "Key does not belong to {gradle_json.keys()}"
+                            f"Key does not belong to {gradle_json.keys()}"
                             )
     return gradle_json
 
@@ -1036,7 +1036,7 @@ def clone_p4a(p4a_dir: str, url: str):
     subprocess.run(
                 untar_command,
                 capture_output=True,
-                check=False
+                check=True
                 )
 
     with open("buildozer.spec", "r", encoding="utf-8") as build_file:

--- a/kvdeveloper/module.py
+++ b/kvdeveloper/module.py
@@ -1038,3 +1038,18 @@ def clone_p4a(p4a_dir: str, url: str):
                 capture_output=True,
                 check=False
                 )
+
+    with open("buildozer.spec", "r", encoding="utf-8") as build_file:
+        content = build_file.readlines()
+
+    with open("buildozer.spec", "w", encoding="utf-8") as target_build_file:
+        for line in content:
+            # Comment line with p4a.source_dir
+            if line.lstrip().startswith('p4a.source_dir'):
+                line = '#' + line
+
+            target_build_file.write(line)
+
+        line = f"p4a.source_dir = {p4a_dir}"
+        console.print(f"Inserting at buildozer.spec: {line}")
+        target_build_file.write(f"{line}\n")

--- a/kvdeveloper/templates/p4a/build.tmpl.gradle
+++ b/kvdeveloper/templates/p4a/build.tmpl.gradle
@@ -1,0 +1,132 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+       google()
+       jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.1'
+        {%- gradle_classpath %}
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
+        {%- for repo in args.gradle_repositories %}
+        {{repo}}
+        {%- endfor %}
+    }
+}
+
+{% if is_library %}
+apply plugin: 'com.android.library'
+{% else %}
+apply plugin: 'com.android.application'
+{% endif %}
+
+// gradle_plugin is the same as gradle_classpath (i think) 
+{%- gradle_plugin %}
+
+android {
+    namespace '{{ args.package }}'
+    compileSdkVersion {{ android_api }}
+    buildToolsVersion '{{ build_tools_version }}'
+    defaultConfig {
+        minSdkVersion {{ args.min_sdk_version }}
+        targetSdkVersion {{ android_api }}
+        versionCode {{ args.numeric_version }}
+        versionName '{{ args.version }}'
+        manifestPlaceholders = {{ args.manifest_placeholders}}
+    }
+
+	packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+        {% if debug_build -%}
+        doNotStrip '**/*.so'
+        {% else %}
+        exclude 'lib/**/gdbserver'
+        exclude 'lib/**/gdb.setup'
+        {%- endif %}
+	}
+	
+
+	{% if args.sign -%}
+	signingConfigs {
+		release {
+			storeFile file(System.getenv("P4A_RELEASE_KEYSTORE"))
+			keyAlias System.getenv("P4A_RELEASE_KEYALIAS")
+			storePassword System.getenv("P4A_RELEASE_KEYSTORE_PASSWD")
+			keyPassword System.getenv("P4A_RELEASE_KEYALIAS_PASSWD")
+		}
+	}
+
+    {%- endif %}
+
+    {% if args.packaging_options -%}
+    packagingOptions {
+        {%- for option in args.packaging_options %}
+        {{option}}
+        {%- endfor %}
+    }
+    {%- endif %}
+
+    buildTypes {
+        debug {
+        }
+        release {
+            {% if args.sign -%}
+            signingConfig signingConfigs.release
+            {%- endif %}
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+        {%- for option in args.compile_options %}
+        {{option}}
+        {%- endfor %}
+    }
+
+    sourceSets {
+        main {
+            jniLibs.srcDir 'libs'
+            java {
+
+                {%- for adir, pattern in args.extra_source_dirs -%}
+                    srcDir '{{adir}}'
+                {%- endfor -%}
+
+            }
+        }
+    }
+
+    aaptOptions {
+        noCompress "tflite"
+    }
+
+}
+
+dependencies {
+    {%- gradle_bom %}
+    {%- gradle_dep %}
+
+    {%- for aar in aars %}
+    implementation(name: '{{ aar }}', ext: 'aar')
+    {%- endfor -%}
+    {%- for jar in jars %}
+    implementation files('src/main/libs/{{ jar }}')
+    {%- endfor -%}
+    {%- if args.depends -%}
+    {%- for depend in args.depends %}
+    implementation '{{ depend }}'
+    {%- endfor %}
+    {%- endif %}
+    {% if args.presplash_lottie %}
+    implementation 'com.airbnb.android:lottie:6.1.0'
+    {%- endif %}
+}

--- a/kvdeveloper/templates/p4a/gradle.json
+++ b/kvdeveloper/templates/p4a/gradle.json
@@ -1,0 +1,6 @@
+{
+    "classpaths": [],
+    "plugins": [],
+    "boms": [],
+    "deps": []
+}

--- a/kvdeveloper/utils.py
+++ b/kvdeveloper/utils.py
@@ -1,11 +1,5 @@
 from typing import Dict, Literal
-import io
 import re
-import os
-import json
-import requests
-import subprocess
-
 
 def replace_placeholders(content: str, variables: Dict[str, str]) -> str:
     """
@@ -87,55 +81,3 @@ def name_parser(name: str, parse_type: Literal["screen", "project"]) -> str:
         )
 
     return pascal_case
-
-def read_gradle_json(path: str):
-    """
-    gradle.json from path to dict
-    :param path: Path of the gradle.json
-    :return:
-        Python dict with the keywords ['classpath', 'plugin', 'bom', 'dep']
-        For each of the keys it does set(value) to avoid duplicates.
-    """
-    gradle_json = {
-        'classpath': [],
-        'plugin': [],
-        'bom': [],
-        'dep': []
-        }
-
-    if os.path.exists(path):
-        with open(path, "r", encoding="UTF-8") as file:
-            g_json = json.load(file)
-            for k, v in g_json.items():
-                if gradle_json.get(k) is not None:
-                    gradle_json[k].extend(v)
-                    gradle_json[k] = list(set(gradle_json[k]))
-
-                else:
-                    raise ValueError(
-                            "Key does not belong to {gradle_json.keys()}"
-                            )
-    return gradle_json
-
-def clone_p4a(p4a_dir: str):
-    with requests.get(P4A_URL, stream=True) as response:
-        response.raise_for_status()
-        with open(f"{p4a_dir}.tar.gz", 'wb') as file:
-            for chunk in response.iter_content(
-                    chunk_size=io.DEFAULT_BUFFER_SIZE): 
-                file.write(chunk)
-
-    console.print(f"{p4a_dir} Creating it...")
-    os.mkdir(p4a_dir)
-    untar_command = [
-            "tar", "-xvzf", "python-for-android.tar.gz",
-            "-C", "python-for-android",
-            "--strip-components=1"
-            ]
-
-    console.print(' '.join(untar_command))
-    subprocess.run(
-                untar_command,
-                capture_output=True,
-                check=False
-                )

--- a/kvdeveloper/utils.py
+++ b/kvdeveloper/utils.py
@@ -1,5 +1,10 @@
 from typing import Dict, Literal
+import io
 import re
+import os
+import json
+import requests
+import subprocess
 
 
 def replace_placeholders(content: str, variables: Dict[str, str]) -> str:
@@ -82,3 +87,55 @@ def name_parser(name: str, parse_type: Literal["screen", "project"]) -> str:
         )
 
     return pascal_case
+
+def read_gradle_json(path: str):
+    """
+    gradle.json from path to dict
+    :param path: Path of the gradle.json
+    :return:
+        Python dict with the keywords ['classpath', 'plugin', 'bom', 'dep']
+        For each of the keys it does set(value) to avoid duplicates.
+    """
+    gradle_json = {
+        'classpath': [],
+        'plugin': [],
+        'bom': [],
+        'dep': []
+        }
+
+    if os.path.exists(path):
+        with open(path, "r", encoding="UTF-8") as file:
+            g_json = json.load(file)
+            for k, v in g_json.items():
+                if gradle_json.get(k) is not None:
+                    gradle_json[k].extend(v)
+                    gradle_json[k] = list(set(gradle_json[k]))
+
+                else:
+                    raise ValueError(
+                            "Key does not belong to {gradle_json.keys()}"
+                            )
+    return gradle_json
+
+def clone_p4a(p4a_dir: str):
+    with requests.get(P4A_URL, stream=True) as response:
+        response.raise_for_status()
+        with open(f"{p4a_dir}.tar.gz", 'wb') as file:
+            for chunk in response.iter_content(
+                    chunk_size=io.DEFAULT_BUFFER_SIZE): 
+                file.write(chunk)
+
+    console.print(f"{p4a_dir} Creating it...")
+    os.mkdir(p4a_dir)
+    untar_command = [
+            "tar", "-xvzf", "python-for-android.tar.gz",
+            "-C", "python-for-android",
+            "--strip-components=1"
+            ]
+
+    console.print(' '.join(untar_command))
+    subprocess.run(
+                untar_command,
+                capture_output=True,
+                check=False
+                )

--- a/kvdeveloper/utils.py
+++ b/kvdeveloper/utils.py
@@ -1,5 +1,7 @@
 from typing import Dict, Literal
+import tarfile
 import re
+import os
 
 def replace_placeholders(content: str, variables: Dict[str, str]) -> str:
     """
@@ -81,3 +83,20 @@ def name_parser(name: str, parse_type: Literal["screen", "project"]) -> str:
         )
 
     return pascal_case
+
+
+def extract_tar_file(tar_file_path: str, extract_to_path: str) -> None:
+    """
+    Extracts a .tar file to a specified directory.
+    
+    Args:
+        tar_file_path (str): Path to the .tar file.
+        extract_to_path (str): Directory to extract the files into.
+    """
+    try:
+        with tarfile.open(tar_file_path, 'r') as tar:
+            tar.extractall(path=extract_to_path)
+            print(f"Extracted '{tar_file_path}' to '{extract_to_path}' successfully.")
+
+    except Exception as e:
+        print(f"Error extracting file: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "kvdeveloper"
 dynamic = ["version"]
 dependencies = [
   "kivy>=2.0.0",
-  "kivymd>=2.0.0",
+  "kivymd@git+https://github.com/kivymd/KivyMD/",
   "pillow>=10.0.0",
   "typer>=0.12.3",
   "rich>=13.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "pillow>=10.0.0",
   "typer>=0.12.3",
   "rich>=13.7.1",
+  "requests>=2.32.0"
 ]
 requires-python = ">=3.9"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ all = [
   "**/*.spec",
   "**/*.js",
   "**/*.css",
+  "templates/p4a/build.tmpl.gradle",
+  "templates/p4a/gradle.json",
 ]
 
 [tool.setuptools.exclude-package-data]


### PR DESCRIPTION
This firebase integration has the following two commands:
1. add-firebase: Add firebase service.
2. update-gradle: Update build.tmpl.gradle
---
The summary in short what this does:
1. Create a gradle.json file to save the following:
1.1 classpath
1.2 plugin
1.3 bom
1.4 dep

2. clone p4a using the version v.2024.01.21
3. Modify buildozer.spec to point to the local p4a repo that got cloned so that It builds from there.
4. Modify pythonforandroid/bootstraps/common/build/templates/build.tmpl.gradle to insert the contents of gradle.json.
5. Copy google-services.json to pythonforandroid/bootstraps/common/build

---
I don't like this solution because It's not the most clean nor understandable (atleast for me) but It works and extensible to add components according to the firebase dependency, e.g: when adding the com.google.android.gms:play-services-ads add Kivmob https://github.com/MichaelStott/KivMob
---
Notes: 
1. P4A Clone repo is not done through Git, it download with requests it's content without git history to reduce the size.
2. To extract the P4A Repo the command used is "tar" this requires Linux or Windows >= 10, I think you Use windows 7 so check that.
3.

## Summary by Sourcery

New Features:
- Added Firebase integration with two new commands: `add-firebase` and `update-gradle`.