### PR TITLE
feat: P4A Variables to sign AAB to release to Google Playstore

### DIFF
--- a/kvdeveloper/build_files/github/buildozer_android_action.yml
+++ b/kvdeveloper/build_files/github/buildozer_android_action.yml
@@ -128,8 +128,14 @@ jobs:
         id: buildozer
         run: |
           yes | buildozer -v android debug
+
+        # Android App Bundle (Signed) [Required by Google Play]
+        # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
+        # echo "P4A_RELEASE_KEYSTORE=$PWD/.keystores/yourkey.keystore" >> $GITHUB_ENV
+        # echo "P4A_RELEASE_KEYSTORE_PASSWD=your_keystore_password" >> $GITHUB_ENV
+        # echo "P4A_RELEASE_KEYALIAS_PASSWD=your_keyalias_password" >> $GITHUB_ENV
+        # echo "P4A_RELEASE_KEYALIAS=your_keyalias" >> $GITHUB_ENV
         # yes | buildozer -v android release
-        # run this for generating aab (Android App Bundle) [Required by google play]
 
       # Upload artifacts
       - name: Upload APK artifact


### PR DESCRIPTION
To upload an application to Google PlayStore you need to create an Android App Bundle (AAB) that is signed.
Python-for-android signs an AAB through the following environment variables:
1. P4A_RELEASE_KEYSTORE
2. P4A_RELEASE_KEYSTORE_PASSWD
3. P4A_RELEASE_KEYALIAS_PASSWD
4. P4A_RELEASE_KEYALIAS

I added as a feature these variables to the github workflow: buildozer_android_action.yml to allow future users to easily sign their apps.

I included this guide:
https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641

## Summary by Sourcery

CI:
- Added P4A environment variables to the build workflow to sign AABs for Google Play Store releases.