### PR TITLE
feat: Github secrets to privately use P4A Release keystore

### DIFF
--- a/kvdeveloper/build_files/github/buildozer_android_action.yml
+++ b/kvdeveloper/build_files/github/buildozer_android_action.yml
@@ -123,6 +123,22 @@ jobs:
           pip install --upgrade pip
           pip install buildozer cython==0.29.33
 
+      
+      # Android App Bundle (Signed) [Required by Google Play]
+      # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
+      - name: Set environment variables
+        env:
+          P4A_RELEASE_KEYSTORE: ${{ secrets.P4A_RELEASE_KEYSTORE }}
+          P4A_RELEASE_KEYSTORE_PASSWD: ${{ secrets.P4A_RELEASE_KEYSTORE_PASSWD }}
+          P4A_RELEASE_KEYALIAS_PASSWD: ${{ secrets.P4A_RELEASE_KEYALIAS_PASSWD }}
+          P4A_RELEASE_KEYALIAS: ${{ secrets.P4A_RELEASE_KEYALIAS }}
+
+        run: |
+          echo "P4A_RELEASE_KEYSTORE=$P4A_RELEASE_KEYSTORE" >> $GITHUB_ENV
+          echo "P4A_RELEASE_KEYSTORE_PASSWD=$P4A_RELEASE_KEYSTORE_PASSWD" >> $GITHUB_ENV
+          echo "P4A_RELEASE_KEYALIAS_PASSWD=$P4A_RELEASE_KEYALIAS_PASSWD" >> $GITHUB_ENV
+          echo "P4A_RELEASE_KEYALIAS=$P4A_RELEASE_KEYALIAS" >> $GITHUB_ENV
+
       # Build with Buildozer
       - name: Build with Buildozer
         id: buildozer
@@ -130,11 +146,6 @@ jobs:
           yes | buildozer -v android debug
 
         # Android App Bundle (Signed) [Required by Google Play]
-        # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
-        # echo "P4A_RELEASE_KEYSTORE=$PWD/.keystores/yourkey.keystore" >> $GITHUB_ENV
-        # echo "P4A_RELEASE_KEYSTORE_PASSWD=your_keystore_password" >> $GITHUB_ENV
-        # echo "P4A_RELEASE_KEYALIAS_PASSWD=your_keyalias_password" >> $GITHUB_ENV
-        # echo "P4A_RELEASE_KEYALIAS=your_keyalias" >> $GITHUB_ENV
         # yes | buildozer -v android release
 
       # Upload artifacts


### PR DESCRIPTION
I added your suggestion.

## Summary by Sourcery

CI:
- Store the `P4A_RELEASE_KEYSTORE`, `P4A_RELEASE_KEYSTORE_PASSWD`, `P4A_RELEASE_KEYALIAS_PASSWD`, and `P4A_RELEASE_KEYALIAS` values as GitHub secrets.