### PR TITLE
Android release workflow enhancement

### DIFF
--- a/kvdeveloper/build_files/github/buildozer_android_action.yml
+++ b/kvdeveloper/build_files/github/buildozer_android_action.yml
@@ -123,20 +123,20 @@ jobs:
           pip install --upgrade pip
           pip install buildozer cython==0.29.33
       
-      # Set env variables for P4A Android App Bundle (Signed) [Required by Google Play]
-      # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
-      - name: Set environment variables
-        env:
-          P4A_RELEASE_KEYSTORE: ${{ secrets.P4A_RELEASE_KEYSTORE }}
-          P4A_RELEASE_KEYSTORE_PASSWD: ${{ secrets.P4A_RELEASE_KEYSTORE_PASSWD }}
-          P4A_RELEASE_KEYALIAS_PASSWD: ${{ secrets.P4A_RELEASE_KEYALIAS_PASSWD }}
-          P4A_RELEASE_KEYALIAS: ${{ secrets.P4A_RELEASE_KEYALIAS }}
+      ## Set env variables for P4A Android App Bundle (Signed) [Required by Google Play]
+      ## https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
+      # - name: Set environment variables
+      #   env:
+      #     P4A_RELEASE_KEYSTORE: ${{ secrets.P4A_RELEASE_KEYSTORE }}
+      #     P4A_RELEASE_KEYSTORE_PASSWD: ${{ secrets.P4A_RELEASE_KEYSTORE_PASSWD }}
+      #     P4A_RELEASE_KEYALIAS_PASSWD: ${{ secrets.P4A_RELEASE_KEYALIAS_PASSWD }}
+      #     P4A_RELEASE_KEYALIAS: ${{ secrets.P4A_RELEASE_KEYALIAS }}
 
-        run: |
-          echo "P4A_RELEASE_KEYSTORE=$P4A_RELEASE_KEYSTORE" >> $GITHUB_ENV
-          echo "P4A_RELEASE_KEYSTORE_PASSWD=$P4A_RELEASE_KEYSTORE_PASSWD" >> $GITHUB_ENV
-          echo "P4A_RELEASE_KEYALIAS_PASSWD=$P4A_RELEASE_KEYALIAS_PASSWD" >> $GITHUB_ENV
-          echo "P4A_RELEASE_KEYALIAS=$P4A_RELEASE_KEYALIAS" >> $GITHUB_ENV
+      #   run: |
+      #     echo "P4A_RELEASE_KEYSTORE=$P4A_RELEASE_KEYSTORE" >> $GITHUB_ENV
+      #     echo "P4A_RELEASE_KEYSTORE_PASSWD=$P4A_RELEASE_KEYSTORE_PASSWD" >> $GITHUB_ENV
+      #     echo "P4A_RELEASE_KEYALIAS_PASSWD=$P4A_RELEASE_KEYALIAS_PASSWD" >> $GITHUB_ENV
+      #     echo "P4A_RELEASE_KEYALIAS=$P4A_RELEASE_KEYALIAS" >> $GITHUB_ENV
 
       # Build with Buildozer
       - name: Build with Buildozer

--- a/kvdeveloper/build_files/github/buildozer_android_action.yml
+++ b/kvdeveloper/build_files/github/buildozer_android_action.yml
@@ -128,8 +128,14 @@ jobs:
         id: buildozer
         run: |
           yes | buildozer -v android debug
+
+        # Android App Bundle (Signed) [Required by Google Play]
+        # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
+        # echo "P4A_RELEASE_KEYSTORE=$PWD/.keystores/yourkey.keystore" >> $GITHUB_ENV
+        # echo "P4A_RELEASE_KEYSTORE_PASSWD=your_keystore_password" >> $GITHUB_ENV
+        # echo "P4A_RELEASE_KEYALIAS_PASSWD=your_keyalias_password" >> $GITHUB_ENV
+        # echo "P4A_RELEASE_KEYALIAS=your_keyalias" >> $GITHUB_ENV
         # yes | buildozer -v android release
-        # run this for generating aab (Android App Bundle) [Required by google play]
 
       # Upload artifacts
       - name: Upload APK artifact

--- a/kvdeveloper/build_files/github/buildozer_android_action.yml
+++ b/kvdeveloper/build_files/github/buildozer_android_action.yml
@@ -123,6 +123,22 @@ jobs:
           pip install --upgrade pip
           pip install buildozer cython==0.29.33
 
+      
+      # Android App Bundle (Signed) [Required by Google Play]
+      # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
+      - name: Set environment variables
+        env:
+          P4A_RELEASE_KEYSTORE: ${{ secrets.P4A_RELEASE_KEYSTORE }}
+          P4A_RELEASE_KEYSTORE_PASSWD: ${{ secrets.P4A_RELEASE_KEYSTORE_PASSWD }}
+          P4A_RELEASE_KEYALIAS_PASSWD: ${{ secrets.P4A_RELEASE_KEYALIAS_PASSWD }}
+          P4A_RELEASE_KEYALIAS: ${{ secrets.P4A_RELEASE_KEYALIAS }}
+
+        run: |
+          echo "P4A_RELEASE_KEYSTORE=$P4A_RELEASE_KEYSTORE" >> $GITHUB_ENV
+          echo "P4A_RELEASE_KEYSTORE_PASSWD=$P4A_RELEASE_KEYSTORE_PASSWD" >> $GITHUB_ENV
+          echo "P4A_RELEASE_KEYALIAS_PASSWD=$P4A_RELEASE_KEYALIAS_PASSWD" >> $GITHUB_ENV
+          echo "P4A_RELEASE_KEYALIAS=$P4A_RELEASE_KEYALIAS" >> $GITHUB_ENV
+
       # Build with Buildozer
       - name: Build with Buildozer
         id: buildozer
@@ -130,11 +146,6 @@ jobs:
           yes | buildozer -v android debug
 
         # Android App Bundle (Signed) [Required by Google Play]
-        # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
-        # echo "P4A_RELEASE_KEYSTORE=$PWD/.keystores/yourkey.keystore" >> $GITHUB_ENV
-        # echo "P4A_RELEASE_KEYSTORE_PASSWD=your_keystore_password" >> $GITHUB_ENV
-        # echo "P4A_RELEASE_KEYALIAS_PASSWD=your_keyalias_password" >> $GITHUB_ENV
-        # echo "P4A_RELEASE_KEYALIAS=your_keyalias" >> $GITHUB_ENV
         # yes | buildozer -v android release
 
       # Upload artifacts

--- a/kvdeveloper/build_files/github/buildozer_android_action.yml
+++ b/kvdeveloper/build_files/github/buildozer_android_action.yml
@@ -122,9 +122,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install buildozer cython==0.29.33
-
       
-      # Android App Bundle (Signed) [Required by Google Play]
+      # Set env variables for P4A Android App Bundle (Signed) [Required by Google Play]
       # https://gist.github.com/Guhan-SenSam/fa4ed215ef3419e7b3154de5cb71f641
       - name: Set environment variables
         env:
@@ -145,7 +144,7 @@ jobs:
         run: |
           yes | buildozer -v android debug
 
-        # Android App Bundle (Signed) [Required by Google Play]
+        # Run below command to generate an Android App bundle [Required by Google Play]
         # yes | buildozer -v android release
 
       # Upload artifacts


### PR DESCRIPTION
## Enable Android App Bundle signing with github secrets
This is in context to the pull-request by @sivefunc introducing P4A variables to the env from **github secrets** for signing the **Android App Bundle** `[Required by Google Play]` while building on github with the workflow generated using the CLI.
- https://github.com/Novfensec/KvDeveloper/pull/10

This enables building the signed android app bundle only on github using the saved variables in github secrets.

#### You need to store the following variable values in github secrets:-
- `P4A_RELEASE_KEYSTORE`
- `P4A_RELEASE_KEYSTORE_PASSWD`
- `P4A_RELEASE_KEYALIAS`
- `P4A_RELEASE_KEYALIAS_PASSWD`

#### To generate the workflow in `.github` folder:-
```bash
kvdeveloper config-build-setup android --external github
```

## Summary by Sourcery

Enable signing Android App Bundles during GitHub Actions builds using secrets stored in GitHub.

Enhancements:
- Generate signed Android App Bundles during release builds on GitHub Actions.

CI:
- Use GitHub secrets to store the keystore and key alias passwords for signing Android App Bundles.